### PR TITLE
fix: replace ':' by '_' of the course_id in the zip/json filename

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,13 @@ Unreleased
 
 *
 
+0.3.1 - 2024-03-20
+
+Added
+=====
+
+* Fix filename of credential ZIP/JSON files
+
 0.3.0 - 2024-03-19
 
 Added

--- a/platform_plugin_elm_credentials/__init__.py
+++ b/platform_plugin_elm_credentials/__init__.py
@@ -2,4 +2,4 @@
 Open edx plugin that includes API to generate JSON files in ELMv3.
 """
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"

--- a/platform_plugin_elm_credentials/api/utils.py
+++ b/platform_plugin_elm_credentials/api/utils.py
@@ -66,6 +66,23 @@ def get_fullname(name: str) -> Tuple[str, str]:
     return first_name, last_name
 
 
+def get_filename(course_id: str, user=None) -> str:
+    """
+    Get the filename for the specified course ID and user.
+
+    Args:
+        course_id (str): The unique identifier for the course.
+        user (User, optional): The user object. Defaults to None.
+
+    Returns:
+        str: The filename
+    """
+    course_id = course_id.replace(":", "_")
+    if not user:
+        return f"credentials-{course_id}.zip"
+    return f"credential-{user}-{course_id}.json"
+
+
 def api_field_errors(field_errors: dict, status_code: int) -> Response:
     """
     Build a response with field errors.

--- a/platform_plugin_elm_credentials/tests/test_utils.py
+++ b/platform_plugin_elm_credentials/tests/test_utils.py
@@ -3,7 +3,7 @@ from unittest import TestCase
 
 from ddt import data, ddt, unpack
 
-from platform_plugin_elm_credentials.api.utils import get_fullname, pydantic_error_to_response
+from platform_plugin_elm_credentials.api.utils import get_filename, get_fullname, pydantic_error_to_response
 
 
 @ddt
@@ -19,12 +19,12 @@ class TestUtils(TestCase):
     )
     @unpack
     def test_get_fullname(self, first_name, last_name, full_name):
-        """Test get_fullname."""
+        """Test `get_fullname` function."""
         result = get_fullname(full_name)
         self.assertTupleEqual((first_name, last_name), result)
 
     def test_pydantic_error_to_response(self):
-        """Test pydantic_error_to_response."""
+        """Test `pydantic_error_to_response` function."""
         errors = [
             {"loc": ("expired_at",), "msg": "expired_at error"},
             {"loc": ("to_file",), "msg": "to_file message"},
@@ -32,4 +32,16 @@ class TestUtils(TestCase):
         result = pydantic_error_to_response(errors)
         self.assertEqual(
             result, {"expired_at": "expired_at error", "to_file": "to_file message"}
+        )
+
+    def test_get_filename(self):
+        """Test `get_filename` function."""
+        course_id = "course-v1:edX+DemoX+Demo_Course"
+        result = get_filename(course_id)
+        self.assertEqual(result, "credentials-course-v1_edX+DemoX+Demo_Course.zip")
+
+        user = "test_user"
+        result = get_filename(course_id, user)
+        self.assertEqual(
+            result, "credential-test_user-course-v1_edX+DemoX+Demo_Course.json"
         )

--- a/platform_plugin_elm_credentials/tests/test_views.py
+++ b/platform_plugin_elm_credentials/tests/test_views.py
@@ -87,9 +87,7 @@ class ElmCredentialBuilderAPIViewTest(APITestCase):
         get_user_by_username_or_email_mock.return_value = self.credential_user
         generated_cert_mock.certificate_for_student.return_value = self.certificate
 
-        self.request = self.factory.get(
-            self.url, {"username": self.username, "to_file": False}
-        )
+        self.request = self.factory.get(self.url, {"username": self.username, "to_file": False})
         force_authenticate(self.request, user=self.request_user)
         response = self.view(self.request, course_id=self.course_id)
         response_data = json.loads(response.content)
@@ -140,9 +138,7 @@ class ElmCredentialBuilderAPIViewTest(APITestCase):
         get_user_by_username_or_email_mock.return_value = self.credential_user
         generated_cert_mock.certificate_for_student.return_value = self.certificate
 
-        self.request = self.factory.get(
-            self.url, {"username": self.username, "to_file": False}
-        )
+        self.request = self.factory.get(self.url, {"username": self.username, "to_file": False})
         force_authenticate(self.request, user=self.request_user)
         response = self.view(self.request, course_id=self.course_id)
         response_data = json.loads(response.content)
@@ -194,9 +190,7 @@ class ElmCredentialBuilderAPIViewTest(APITestCase):
         get_user_by_username_or_email_mock.return_value = self.credential_user
         generated_cert_mock.certificate_for_student.return_value = self.certificate
 
-        self.request = self.factory.get(
-            self.url, {"username": self.username, "to_file": False}
-        )
+        self.request = self.factory.get(self.url, {"username": self.username, "to_file": False})
         force_authenticate(self.request, user=self.request_user)
         response = self.view(self.request, course_id=self.course_id)
         response_data = json.loads(response.content)

--- a/platform_plugin_elm_credentials/tests/test_views.py
+++ b/platform_plugin_elm_credentials/tests/test_views.py
@@ -50,6 +50,7 @@ class ElmCredentialBuilderAPIViewTest(APITestCase):
         self.user_enrollments = [Mock(user=self.credential_user)]
 
         self.course_id = "course-v1:edX+DemoX+Demo_Course"
+        self.course_id_filename = self.course_id.replace(":", "_")
         self.org = "edX"
         self.display_name = "Demo Course"
         self.other_course_settings = {
@@ -86,7 +87,9 @@ class ElmCredentialBuilderAPIViewTest(APITestCase):
         get_user_by_username_or_email_mock.return_value = self.credential_user
         generated_cert_mock.certificate_for_student.return_value = self.certificate
 
-        self.request = self.factory.get(self.url, {"username": self.username, "to_file": False})
+        self.request = self.factory.get(
+            self.url, {"username": self.username, "to_file": False}
+        )
         force_authenticate(self.request, user=self.request_user)
         response = self.view(self.request, course_id=self.course_id)
         response_data = json.loads(response.content)
@@ -137,7 +140,9 @@ class ElmCredentialBuilderAPIViewTest(APITestCase):
         get_user_by_username_or_email_mock.return_value = self.credential_user
         generated_cert_mock.certificate_for_student.return_value = self.certificate
 
-        self.request = self.factory.get(self.url, {"username": self.username, "to_file": False})
+        self.request = self.factory.get(
+            self.url, {"username": self.username, "to_file": False}
+        )
         force_authenticate(self.request, user=self.request_user)
         response = self.view(self.request, course_id=self.course_id)
         response_data = json.loads(response.content)
@@ -189,7 +194,9 @@ class ElmCredentialBuilderAPIViewTest(APITestCase):
         get_user_by_username_or_email_mock.return_value = self.credential_user
         generated_cert_mock.certificate_for_student.return_value = self.certificate
 
-        self.request = self.factory.get(self.url, {"username": self.username, "to_file": False})
+        self.request = self.factory.get(
+            self.url, {"username": self.username, "to_file": False}
+        )
         force_authenticate(self.request, user=self.request_user)
         response = self.view(self.request, course_id=self.course_id)
         response_data = json.loads(response.content)
@@ -252,7 +259,7 @@ class ElmCredentialBuilderAPIViewTest(APITestCase):
         self.assertEqual(response.headers["Content-Type"], "application/zip")
         self.assertEqual(
             response.headers["Content-Disposition"],
-            f'attachment; filename="credentials-{self.course_id}.zip"',
+            f'attachment; filename="credentials-{self.course_id_filename}.zip"',
         )
 
     @generated_cert_patch


### PR DESCRIPTION
### Description
This PR updates the ZIP/JSON filename generated for the endpoint. When using the Windows OS, you cannot use the `:` character in file names. Since the course ID in Open edX has the format: `course-v1:{organization}+{course_number}+{course_run}`, we must replace the `:` character with another valid character, for example: `_`

### Testing Instructions
1. Install this plugin in your environment and checkout to this branch.
2. Activate certificates in the platform following [these steps](https://discuss.openedx.org/t/certificates-and-maple/6871/4).
3. Configure the grading in your course. If you want, you can use [this test course](https://github.com/eduNEXT/platform-plugin-elm-credentials/files/14652912/elm-course.tar.gz)
4. Complete the course with at least the minimum grade.
5. Generate the certificate for at least two students. You can go to the progress section and request the certificate.
6. As an instructor generate the ZIP file that contains the credentials of all students:

    ```bash
    curl --location --request GET 'http://local.edly.io:8000/platform-plugin-elm-credentials/{course-id}/api/credential-builder' \
    --header 'Authorization: Bearer {access-token}'
    ``` 
7. Now you can see that the files have the character `_`, instead of `:` in the course id.